### PR TITLE
add: nucleo as an experimental matcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "fuzzy-matcher",
  "iced",
  "log",
+ "nucleo",
  "rust_search",
  "swayipc",
  "thiserror",
@@ -612,12 +613,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "cov-mark"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ffa3d3e0138386cd4361f63537765cac7ee40698028844635a54495a92f67f3"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset 0.9.0",
+ "scopeguard",
 ]
 
 [[package]]
@@ -701,6 +732,12 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "equivalent"
@@ -1672,6 +1709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metal"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1868,28 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nucleo"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae5331f4bcce475cf28cb29c95366c3091af4b0aa7703f1a6bc858f29718fdf3"
+dependencies = [
+ "nucleo-matcher",
+ "parking_lot 0.12.1",
+ "rayon",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b702b402fe286162d1f00b552a046ce74365d2ac473a2607ff36ba650f9bd57"
+dependencies = [
+ "cov-mark",
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2257,6 +2325,26 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rctree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ swayipc = "3.0.1"
 
 # git repositories plugin
 rust_search = "2.0.0"
+nucleo = "0.2.1"

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,6 +15,22 @@ pub struct Entry {
     pub meta: String,
 }
 
+impl std::fmt::Display for Entry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "({}, {}, {}, ,{})",
+            self.id, self.title, self.action, self.meta
+        )
+    }
+}
+
+impl AsRef<str> for Entry {
+    fn as_ref(&self) -> &str {
+        self.title.as_str()
+    }
+}
+
 pub enum PluginRequest {
     Search(String),
     Timeout,

--- a/src/plugin/applications.rs
+++ b/src/plugin/applications.rs
@@ -152,9 +152,11 @@ impl ApplicationsPlugin {
     ) -> ApplicationsPlugin {
         let (app_channel_out, plugin_channel_in) = iced::futures::channel::mpsc::channel(100);
 
-        // let config = nucleo::Config::DEFAULT;
         // let matcher = nucleo::Nucleo::new(config, _, None, 0);
-        let matcher = nucleo::Matcher::default();
+        // let matcher = nucleo::Matcher::default();
+        let mut config = nucleo::Config::DEFAULT;
+        config.prefer_prefix = true;
+        let matcher = nucleo::Matcher::new(config);
 
         return ApplicationsPlugin {
             plugin: crate::model::Plugin {

--- a/src/plugin/windows.rs
+++ b/src/plugin/windows.rs
@@ -35,6 +35,10 @@ impl WindowsPlugin {
         }
         let mut sway = connection_result.unwrap();
 
+        let mut config = nucleo::Config::DEFAULT;
+        config.prefer_prefix = true;
+        let matcher = nucleo::Matcher::new(config);
+
         return WindowsPlugin {
             all_entries: WindowsPlugin::all_entries(&mut sway),
             plugin_channel_in,
@@ -47,7 +51,7 @@ impl WindowsPlugin {
                 entries: vec![],
             },
             sway,
-            matcher: nucleo::Matcher::default(),
+            matcher,
         };
     }
 


### PR DESCRIPTION
Draft to see how the `nucleo` matcher might improve matching of results.


Convenience uri's:

With `prefefer_prefix`:

```
 nix run github:a-kenji/centerpiece/feat/switch-to-nucleo
```

Without `prefer_prefix`:

```
nix run github:a-kenji/centerpiece/49fe5945cf7fa5ab45875dc19f3d141220ce1276
```

Only implemented for the following plugins:
- applications
- windows