### PR TITLE
🐛 remove fuzzy matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,6 @@ dependencies = [
  "battery",
  "chrono",
  "freedesktop-desktop-entry",
- "fuzzy-matcher",
  "iced",
  "log",
  "serde",
@@ -1065,15 +1064,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,9 +13,6 @@ anyhow = { version = "1.0.75", features = ["backtrace"] }
 
 # application window
 iced = { version = "0.10.0", features = ["svg"] }
-
-# plugins
-fuzzy-matcher = "0.3.7"
 async-trait = "0.1.74"
 async-std = "1.12.0"
 

--- a/client/src/plugin/utils.rs
+++ b/client/src/plugin/utils.rs
@@ -152,31 +152,18 @@ pub trait Plugin {
 }
 
 pub fn search(entries: Vec<crate::model::Entry>, query: &String) -> Vec<crate::model::Entry> {
-    let matcher = fuzzy_matcher::skim::SkimMatcherV2::default();
-
     if query.is_empty() {
         let mut sorted_entries = entries.clone();
         sorted_entries.sort_by_key(|entry| entry.title.clone());
         return sorted_entries;
     }
 
-    let mut filtered_entries = entries
+    return entries
         .into_iter()
-        .filter_map(|entry| {
-            let keywords = format!("{} {}", entry.title, entry.meta);
-            let match_result = matcher.fuzzy_indices(&keywords, query);
-            if match_result.is_none() {
-                return None;
-            }
-            let (score, _) = match_result.unwrap();
-            return Some((score, entry));
+        .filter(|entry| {
+            let keywords = format!("{} {}", entry.title, entry.meta).to_lowercase();
+            return keywords.contains(&query.to_lowercase());
         })
-        .collect::<Vec<(i64, crate::model::Entry)>>();
-
-    filtered_entries.sort_by(|(a_score, _), (b_score, _)| b_score.cmp(a_score));
-    return filtered_entries
-        .into_iter()
-        .map(|(_, entry)| entry)
         .collect::<Vec<crate::model::Entry>>();
 }
 

--- a/client/src/plugin/utils.rs
+++ b/client/src/plugin/utils.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use fuzzy_matcher::FuzzyMatcher;
 use iced::futures::StreamExt;
 
 pub fn spawn<PluginType: Plugin + std::marker::Send + 'static>(


### PR DESCRIPTION
This removes fuzzy matching of the search query entirely. Instead, only exact (partial) matches will be displayed.