### PR TITLE
✨ Brave history

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -77,7 +77,9 @@ impl Application for Centerpiece {
                 iced::Event::Keyboard(iced::keyboard::Event::KeyPressed {
                     key_code: iced::keyboard::KeyCode::Enter,
                     ..
-                }) => self.activate_selected_entry().unwrap_or(iced::Command::none()),
+                }) => self
+                    .activate_selected_entry()
+                    .unwrap_or(iced::Command::none()),
 
                 iced::Event::Keyboard(iced::keyboard::Event::KeyReleased {
                     key_code: iced::keyboard::KeyCode::Escape,
@@ -125,11 +127,13 @@ impl Application for Centerpiece {
             crate::plugin::utils::spawn::<crate::plugin::git_repositories::GitRepositoriesPlugin>(),
             crate::plugin::utils::spawn::<crate::plugin::brave::bookmarks::BookmarksPlugin>(),
             crate::plugin::utils::spawn::<crate::plugin::system::SystemPlugin>(),
-            crate::plugin::utils::spawn::<crate::plugin::resource_monitor::battery::BatteryPlugin>(),
+            crate::plugin::utils::spawn::<crate::plugin::resource_monitor::battery::BatteryPlugin>(
+            ),
             crate::plugin::utils::spawn::<crate::plugin::resource_monitor::cpu::CpuPlugin>(),
             crate::plugin::utils::spawn::<crate::plugin::resource_monitor::memory::MemoryPlugin>(),
             crate::plugin::utils::spawn::<crate::plugin::resource_monitor::disks::DisksPlugin>(),
             crate::plugin::utils::spawn::<crate::plugin::clock::ClockPlugin>(),
+            crate::plugin::utils::spawn::<crate::plugin::brave::history::HistoryPlugin>(),
         ]);
     }
 
@@ -308,9 +312,11 @@ impl Centerpiece {
     fn activate_selected_entry(&mut self) -> Option<iced::Command<Message>> {
         let active_entry_id = self.active_entry_id()?.clone();
 
-        let entry = self.entries().into_iter().find(|entry| {
-            entry.id == *active_entry_id
-        })?.clone();
+        let entry = self
+            .entries()
+            .into_iter()
+            .find(|entry| entry.id == *active_entry_id)?
+            .clone();
 
         let plugin = self.plugins.iter_mut().find(|plugin| {
             plugin

--- a/client/src/plugin/brave/history.rs
+++ b/client/src/plugin/brave/history.rs
@@ -1,0 +1,83 @@
+use crate::plugin::utils::Plugin;
+use anyhow::Context;
+
+use sqlite::State;
+
+pub struct HistoryPlugin {
+    entries: Vec<crate::model::Entry>,
+}
+
+impl Plugin for HistoryPlugin {
+    fn id() -> &'static str {
+        return "brave-history";
+    }
+
+    fn priority() -> u32 {
+        return 99;
+    }
+
+    fn title() -> &'static str {
+        return "󰃃 History";
+    }
+
+    fn entries(&self) -> Vec<crate::model::Entry> {
+        return self.entries.clone();
+    }
+
+    fn new() -> Self {
+        println!("------------------------------------------ HELLOOOOOOOOOO");
+
+        let home_directory = std::env::var("HOME").unwrap();
+
+        let history_file_path = std::path::Path::new(&home_directory)
+            .join(".config/BraveSoftware/Brave-Browser/Default/History");
+
+        // TODO: database is locked, needs to becopied first
+        let connection = sqlite::open(history_file_path).unwrap();
+
+        let query = "SELECT * FROM urls";
+        connection.execute(query).unwrap();
+        let url_rows = connection
+            .prepare(query)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.unwrap());
+
+        for url_row in url_rows {
+            println!("title = {}", url_row.read::<&str, _>("title"));
+            println!("url = {}", url_row.read::<&str, _>("url"));
+        }
+
+        return Self { entries: vec![] };
+    }
+
+    fn update_entries(&mut self) -> anyhow::Result<()> {
+        self.entries.clear();
+        // TODO: add entries here
+
+        return Ok(());
+    }
+
+    fn activate(
+        &mut self,
+        entry: crate::model::Entry,
+        plugin_channel_out: &mut iced::futures::channel::mpsc::Sender<crate::Message>,
+    ) -> anyhow::Result<()> {
+        std::process::Command::new("brave")
+            .arg(&entry.id)
+            .spawn()
+            .context(format!(
+                "Failed to launch brave in app mode while activating entry with id '{}'.",
+                entry.id
+            ))?;
+
+        plugin_channel_out
+            .try_send(crate::Message::Exit)
+            .context(format!(
+                "Failed to send message to exit application while activating entry with id '{}'.",
+                entry.id
+            ))?;
+
+        return Ok(());
+    }
+}

--- a/client/src/plugin/brave/mod.rs
+++ b/client/src/plugin/brave/mod.rs
@@ -1,3 +1,4 @@
 pub mod bookmarks;
+pub mod history;
 pub mod progressive_web_apps;
 pub mod utils;


### PR DESCRIPTION
This plugin will parse your Brave browser history and add it to the bottom of the centerpiece search list. This should give a nice fallback in case no other plugin entries match your search. Furthermore, this is another step on making the omnibox in your browser obsolete :blush:.

The list of history entries is sorted by the `number of visits to a page` followed by the `last visit to a page`.

This resolves #24.