### PR TITLE
 ✨ init cli and surface version information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +534,7 @@ dependencies = [
  "async-trait",
  "battery",
  "chrono",
+ "clap",
  "dbus",
  "freedesktop-desktop-entry",
  "iced",
@@ -524,6 +573,46 @@ dependencies = [
  "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "clap"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clipboard-win"
@@ -611,6 +700,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -1356,6 +1451,12 @@ dependencies = [
  "widestring",
  "winapi",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -3538,6 +3639,12 @@ dependencies = [
  "svgtypes",
  "tiny-skia-path 0.10.0",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "value-bag"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -7,9 +7,10 @@ edition = "2021"
 
 [dependencies]
 # general
+anyhow = { version = "1.0.78", features = ["backtrace"] }
+clap = { version = "4.4.16", features = ["derive",] }
 log = { version = "0.4.20", features = ["kv_unstable_serde"] }
 simple_logger = { version = "4.3.3", features = ["colors", "threads", "timestamps", "stderr"] }
-anyhow = { version = "1.0.78", features = ["backtrace"] }
 
 # application window
 iced = { version = "0.10.0", features = ["svg"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "centerpiece"
+description = "Your trusty omnibox search."
 version.workspace = true
 edition = "2021"
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -1,0 +1,22 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version = CliArgs::version(), about, long_about=None) ]
+#[command(next_line_help = true)]
+pub(crate) struct CliArgs {}
+
+impl CliArgs {
+    /// Surface current version together with the current git revision and date,
+    /// if available
+    fn version() -> &'static str {
+        const VERSION: &str = env!("CARGO_PKG_VERSION");
+        let date = option_env!("GIT_DATE")
+            .map(|date| format!(" - {}", date))
+            .unwrap_or_default();
+        let rev = option_env!("GIT_REV")
+            .map(|rev| format!(" - {}", rev))
+            .unwrap_or_default();
+        // This is a memory leak, only use sparingly.
+        Box::leak(format!("{VERSION}{date}{rev}").into_boxed_str())
+    }
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,10 +1,13 @@
+use clap::Parser;
 use iced::Application;
 
+mod cli;
 mod component;
 mod model;
 mod plugin;
 
 pub fn main() -> iced::Result {
+    let _args = crate::cli::CliArgs::parse();
     simple_logger::init_with_level(log::Level::Info).unwrap();
     Centerpiece::run(Centerpiece::settings())
 }

--- a/flake.nix
+++ b/flake.nix
@@ -66,10 +66,15 @@
           cargoClippyExtraArgs = "--all-targets --all-features";
         }
       );
+      GIT_DATE = "${builtins.substring 0 4 self.lastModifiedDate}-${
+          builtins.substring 4 2 self.lastModifiedDate
+        }-${builtins.substring 6 2 self.lastModifiedDate}";
+      GIT_REV = self.shortRev or "Not committed yet.";
     in
     {
       devShells.${system}.default = pkgs.mkShell {
-        inherit nativeBuildInputs buildInputs;
+        inherit nativeBuildInputs buildInputs
+        GIT_DATE GIT_REV;
         packages = devInputs;
         LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
           pkgs.wayland
@@ -87,6 +92,8 @@
               nativeBuildInputs
               buildInputs
               pname
+              GIT_REV
+              GIT_DATE
             ;
             postInstall = ''
               wrapProgram "$out/bin/${pname}" \


### PR DESCRIPTION
✨ init cli and surface version information

 Fixes #28

Depends on  #49 and is a first step towards an alternative frontend.

Example:

`centerpiece --version`:

```
centerpiece 0.8.0 - 2024-01-21 - ca255f4
```

