### PR TITLE
🐛 applications: deduplicate entries

### DIFF
--- a/client/src/model.rs
+++ b/client/src/model.rs
@@ -7,7 +7,7 @@ pub struct Plugin {
     pub app_channel_out: iced::futures::channel::mpsc::Sender<PluginRequest>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Ord, PartialOrd)]
 pub struct Entry {
     pub id: String,
     pub title: String,

--- a/client/src/plugin/applications.rs
+++ b/client/src/plugin/applications.rs
@@ -129,6 +129,9 @@ impl Plugin for ApplicationsPlugin {
             })
             .collect();
 
+        self.entries.sort();
+        self.entries.dedup();
+
         Ok(())
     }
 


### PR DESCRIPTION
Deduplicate desktop entries of the applications plugin

Fix: #63


Alternative: 
Deduplicate at the model level.