### PR TITLE
✅ add `treefmt` as module, devShell, check, ci integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,9 @@
 [workspace]
 resolver = "2"
 
-default-members = [
-    "client",
-]
+default-members = ["client"]
 
-members = [
-    "client",
-    "services/index-git-repositories",
-]
+members = ["client", "services/index-git-repositories"]
 
 [workspace.package]
 version = "0.8.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,9 +10,14 @@ edition = "2021"
 [dependencies]
 # general
 anyhow = { version = "1.0.78", features = ["backtrace"] }
-clap = { version = "4.4.16", features = ["derive",] }
+clap = { version = "4.4.16", features = ["derive"] }
 log = { version = "0.4.20", features = ["kv_unstable_serde"] }
-simple_logger = { version = "4.3.3", features = ["colors", "threads", "timestamps", "stderr"] }
+simple_logger = { version = "4.3.3", features = [
+  "colors",
+  "threads",
+  "timestamps",
+  "stderr",
+] }
 
 # application window
 iced = { version = "0.10.0", features = ["svg"] }

--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,46 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1705856552,
+        "narHash": "sha256-JXfnuEf5Yd6bhMs/uvM67/joxYKoysyE3M2k6T3eWbg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "612f97239e2cc474c13c9dafa0df378058c5ad8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1707300477,
+        "narHash": "sha256-qQF0fEkHlnxHcrKIMRzOETnRBksUK048MXkX0SOmxvA=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "ac599dab59a66304eb511af07b3883114f061b9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,28 +4,19 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     home-manager.url = "github:nix-community/home-manager";
+    treefmt-nix.url = "github:numtide/treefmt-nix/";
     crane = {
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs =
-    {
-      self,
-      nixpkgs,
-      crane,
-      home-manager,
-    }:
+  outputs = { self, nixpkgs, crane, treefmt-nix, ... }:
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
 
-      devInputs = with pkgs; [
-        rustc
-        rustfmt
-        cargo
-      ];
+      devInputs = with pkgs; [ rustc rustfmt cargo ];
 
       nativeBuildInputs = with pkgs; [
         makeWrapper
@@ -44,38 +35,29 @@
 
       craneLib = crane.lib.${system};
       assetFilter = path: _type: builtins.match ".*ttf$" path != null;
-      assetOrCargo =
-        path: type: (assetFilter path type) || (craneLib.filterCargoSources path type);
+      assetOrCargo = path: type:
+        (assetFilter path type) || (craneLib.filterCargoSources path type);
       commonArgs = {
         src = pkgs.lib.cleanSourceWith {
           src = craneLib.path ./.;
           filter = assetOrCargo;
         };
-        inherit
-          pname
-          version
-          buildInputs
-          nativeBuildInputs
-        ;
+        inherit pname version buildInputs nativeBuildInputs;
       };
       cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-      cargoClippy = craneLib.cargoClippy (
-        commonArgs
-        // {
-          inherit cargoArtifacts;
-          cargoClippyExtraArgs = "--all-targets --all-features";
-        }
-      );
+      cargoClippy = craneLib.cargoClippy (commonArgs // {
+        inherit cargoArtifacts;
+        cargoClippyExtraArgs = "--all-targets --all-features";
+      });
       GIT_DATE = "${builtins.substring 0 4 self.lastModifiedDate}-${
           builtins.substring 4 2 self.lastModifiedDate
         }-${builtins.substring 6 2 self.lastModifiedDate}";
       GIT_REV = self.shortRev or "Not committed yet.";
-    in
-    {
+      treefmt = (treefmt-nix.lib.evalModule pkgs ./formatter.nix).config.build;
+    in {
       devShells.${system}.default = pkgs.mkShell {
-        inherit nativeBuildInputs buildInputs
-        GIT_DATE GIT_REV;
-        packages = devInputs;
+        inherit nativeBuildInputs buildInputs GIT_DATE GIT_REV;
+        packages = devInputs ++ [ treefmt.wrapper ];
         LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
           pkgs.wayland
           pkgs.libxkbcommon
@@ -84,56 +66,47 @@
         ];
       };
       packages.${system} = {
-        default = craneLib.buildPackage (
-          commonArgs
-          // {
-            inherit
-              cargoArtifacts
-              nativeBuildInputs
-              buildInputs
-              pname
-              GIT_REV
-              GIT_DATE
-            ;
-            postInstall = ''
-              wrapProgram "$out/bin/${pname}" \
-                --prefix LD_LIBRARY_PATH : ${
-                  pkgs.lib.makeLibraryPath [
-                    pkgs.wayland
-                    pkgs.libxkbcommon
-                    pkgs.vulkan-loader
-                    pkgs.libGL
-                  ]
-                }
-            '';
-            meta = with pkgs.lib; {
-              description = "Your trusty omnibox search.";
-              homepage = "https://github.com/friedow/centerpiece";
-              platforms = platforms.linux;
-              license = licenses.mit;
-              mainProgram = pname;
-              maintainers = [ "friedow" ];
-            };
-          }
-        );
-        index-git-repositories = craneLib.buildPackage (
-          commonArgs
-          // rec {
-            inherit cargoArtifacts;
-            pname = "index-git-repositories";
-            cargoExtraArgs = "-p ${pname}";
-            meta.mainProgram = pname;
-          }
-        );
+        default = craneLib.buildPackage (commonArgs // {
+          inherit cargoArtifacts nativeBuildInputs buildInputs pname GIT_REV
+            GIT_DATE;
+          postInstall = ''
+            wrapProgram "$out/bin/${pname}" \
+              --prefix LD_LIBRARY_PATH : ${
+                pkgs.lib.makeLibraryPath [
+                  pkgs.wayland
+                  pkgs.libxkbcommon
+                  pkgs.vulkan-loader
+                  pkgs.libGL
+                ]
+              }
+          '';
+          meta = with pkgs.lib; {
+            description = "Your trusty omnibox search.";
+            homepage = "https://github.com/friedow/centerpiece";
+            platforms = platforms.linux;
+            license = licenses.mit;
+            mainProgram = pname;
+            maintainers = [ "friedow" ];
+          };
+        });
+        index-git-repositories = craneLib.buildPackage (commonArgs // rec {
+          inherit cargoArtifacts;
+          pname = "index-git-repositories";
+          cargoExtraArgs = "-p ${pname}";
+          meta.mainProgram = pname;
+        });
       };
       checks.${system} = {
-        inherit (self.outputs.packages.${system}) default index-git-repositories;
+        inherit (self.outputs.packages.${system})
+          default index-git-repositories;
         shell = self.outputs.devShells.${system}.default;
+        treefmt = treefmt.check self;
         inherit cargoClippy;
       };
       hmModules.${system}.default = import ./home-manager-module.nix {
         centerpiece = self.outputs.packages.${system}.default;
         inherit (self.outputs.packages.${system}) index-git-repositories;
       };
+      formatter.${system} = treefmt.wrapper;
     };
 }

--- a/formatter.nix
+++ b/formatter.nix
@@ -1,0 +1,12 @@
+_: {
+  projectRootFile = "flake.nix";
+
+  programs = {
+    deadnix.enable = true;
+    nixfmt.enable = true;
+    rustfmt.enable = true;
+    statix.enable = true;
+    taplo.enable = true;
+    yamlfmt.enable = true;
+  };
+}

--- a/services/index-git-repositories/Cargo.toml
+++ b/services/index-git-repositories/Cargo.toml
@@ -5,7 +5,12 @@ edition = "2021"
 
 [dependencies]
 log = { version = "0.4.20", features = ["kv_unstable_serde"] }
-simple_logger = { version = "4.3.3", features = ["colors", "threads", "timestamps", "stderr"] }
+simple_logger = { version = "4.3.3", features = [
+  "colors",
+  "threads",
+  "timestamps",
+  "stderr",
+] }
 
 serde_json = "1.0.113"
 rust_search = "2.0.0"


### PR DESCRIPTION
Adds `treefmt` through the `treefmt-nix` module.

This allows the following integration:

- `nix fmt`: format the code through `nix fmt`
- `treefmt`: exposes a wrapped, configured `treefmt` inside the `devShell`
- `nix flake check`: check and lint the code locally, or the ci

All of these options use the same configuration and will share evaluation cache.

Initalize with the following formatters/linters:
- deadnix
- nixfmt
- rustfmt
- statix
- taplo
- yamllint