### PR TITLE
✨ plugins: add `$GIT_DIRECTORY_NAME` env variable

### DIFF
--- a/client/src/plugin/git_repositories.rs
+++ b/client/src/plugin/git_repositories.rs
@@ -66,12 +66,16 @@ impl Plugin for GitRepositoriesPlugin {
         for command in self.settings.plugin.git_repositories.commands.clone() {
             let parsed_command: Vec<String> = command
                 .into_iter()
-                .map(|command_part| {
-                    if command_part == "$GIT_DIRECTORY" {
-                        entry.id.clone()
-                    } else {
-                        command_part
-                    }
+                .map(|command_part| match command_part.as_ref() {
+                    "$GIT_DIRECTORY" => entry.id.clone(),
+                    "$GIT_DIRECTORY_NAME" => std::path::Path::new(&entry.id)
+                        .file_name()
+                        // We match on a git directory
+                        .unwrap()
+                        .to_str()
+                        .unwrap()
+                        .into(),
+                    _ => command_part,
                 })
                 .collect();
             std::process::Command::new(&parsed_command[0])

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -60,8 +60,11 @@ in {
             [ "alacritty" "--working-directory" "$GIT_DIRECTORY" ]
           ];
           type = lib.types.listOf (lib.types.listOf lib.types.str);
-          description = lib.mdDoc
-            "The commands to launch when an entry is selected. Use the $GIT_DIRECTORY variable to pass in the selected directory.";
+          description = lib.mdDoc ''
+            The commands to launch when an entry is selected.
+            Use the $GIT_DIRECTORY variable to pass in the selected directory.
+            Use the $GIT_DIRECTORY_NAME variable to pass in the selected directory name.
+          '';
           example = [
             [ "code" "--new-window" "$GIT_DIRECTORY" ]
             [ "alacritty" "--command" "lazygit" "--path" "$GIT_DIRECTORY" ]


### PR DESCRIPTION
Expose the `$GIT_DIRECTORY_NAME` environment variable to the git_repositories plugin.

This is useful for setting `app_ids`, or `tmux` session names, for example.

I am not sure about error handling here.
The unwraps are there because:
- We have a git directory, the file name should always succeed.
- It should always be valid Utf8.

We could return an empty string in an error case, that way scripts might still succeed and fill in a default value.