### PR TITLE
feat: allow specifying configuration location

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ plugin:
 
 You can configure centerpiece through yaml or nix.
 
+You can specify alternative configuration locations through:
+- the `--config` flag
+- the `CENTERPIECE_CONFIGURATION_FILE` environment variable
+ 
 ## Using yml
 
 1. Create a `config.yml` file in `~/.config/centerpiece/config.yml`.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 # general
 anyhow = { version = "1.0.78", features = ["backtrace"] }
-clap = { version = "4.5.1", features = ["derive"] }
+clap = { version = "4.5.1", features = ["derive", "env"] }
 log = { version = "0.4.20", features = ["kv_unstable_serde"] }
 simple_logger = { version = "4.3.3", features = [
   "colors",

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -1,9 +1,17 @@
 use clap::Parser;
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Default)]
 #[command(author, version = CliArgs::version(), about, long_about=None) ]
 #[command(next_line_help = true)]
-pub(crate) struct CliArgs {}
+pub(crate) struct CliArgs {
+    #[clap(
+        short,
+        long,
+        help = "The location of the configuration file",
+        env = "CENTERPIECE_CONFIGURATION_FILE"
+    )]
+    pub(crate) config: Option<String>,
+}
 
 impl CliArgs {
     /// Surface current version together with the current git revision and date,

--- a/client/src/plugin/utils.rs
+++ b/client/src/plugin/utils.rs
@@ -173,6 +173,11 @@ pub fn config_directory() -> anyhow::Result<String> {
     Ok(std::env::var("XDG_CONFIG_HOME").unwrap_or(config_in_home))
 }
 
+pub fn centerpiece_default_config_path() -> anyhow::Result<String> {
+    let config_directory = crate::plugin::utils::centerpiece_config_directory()?;
+    Ok(format!("{config_directory}/config.yml"))
+}
+
 pub fn centerpiece_config_directory() -> anyhow::Result<String> {
     let config_directory = config_directory()?;
     Ok(format!("{config_directory}/centerpiece"))


### PR DESCRIPTION
Allow specifying the configuration location through:

- `--config` flag
- `CENTERPIECE_CONFIGURATION_FILE` environment variable
