### PR TITLE
fix: implement full desktop spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,6 @@ dependencies = [
  "sqlite",
  "swayipc",
  "sysinfo",
- "xdg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,9 +1109,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "freedesktop-desktop-entry"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287f89b1a3d88dd04d2b65dfec39f3c381efbcded7b736456039c4ee49d54b17"
+checksum = "c201444ddafb5506fe85265b48421664ff4617e3b7090ef99e42a0070c1aead0"
 dependencies = [
  "dirs 3.0.2",
  "gettext-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
  "sqlite",
  "swayipc",
  "sysinfo",
+ "xdg",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -38,7 +38,6 @@ chrono = "0.4.33"
 
 # applications plugin
 freedesktop-desktop-entry = "0.5.1"
-xdg = "2.5.2"
 
 # sway_windows plugin
 swayipc = "3.0.1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -38,6 +38,7 @@ chrono = "0.4.33"
 
 # applications plugin
 freedesktop-desktop-entry = "0.5.1"
+xdg = "2.5.2"
 
 # sway_windows plugin
 swayipc = "3.0.1"

--- a/client/src/plugin/applications.rs
+++ b/client/src/plugin/applications.rs
@@ -150,15 +150,6 @@ fn path_name(path: &std::path::PathBuf) -> String {
     name_option.unwrap().to_string()
 }
 
-fn data_dirs() -> Vec<std::path::PathBuf> {
-    let base_dirs = xdg::BaseDirectories::new().unwrap();
-    let mut data_dirs: Vec<std::path::PathBuf> = vec![];
-    data_dirs.push(base_dirs.get_data_home());
-    data_dirs.append(&mut base_dirs.get_data_dirs());
-
-    data_dirs.iter().map(|d| d.join("applications")).collect()
-}
-
 impl Plugin for ApplicationsPlugin {
     fn new() -> Self {
         Self { entries: vec![] }
@@ -188,7 +179,8 @@ impl Plugin for ApplicationsPlugin {
         self.entries.clear();
 
         let mut paths: Vec<std::path::PathBuf> =
-            freedesktop_desktop_entry::Iter::new(data_dirs()).collect();
+            freedesktop_desktop_entry::Iter::new(freedesktop_desktop_entry::default_paths())
+                .collect();
 
         paths.sort_by_key(path_name);
         paths.dedup_by_key(|path| path_name(path));

--- a/client/src/plugin/applications.rs
+++ b/client/src/plugin/applications.rs
@@ -150,6 +150,15 @@ fn path_name(path: &std::path::PathBuf) -> String {
     name_option.unwrap().to_string()
 }
 
+fn data_dirs() -> Vec<std::path::PathBuf> {
+    let base_dirs = xdg::BaseDirectories::new().unwrap();
+    let mut data_dirs: Vec<std::path::PathBuf> = vec![];
+    data_dirs.push(base_dirs.get_data_home());
+    data_dirs.append(&mut base_dirs.get_data_dirs());
+
+    data_dirs.iter().map(|d| d.join("applications")).collect()
+}
+
 impl Plugin for ApplicationsPlugin {
     fn new() -> Self {
         Self { entries: vec![] }
@@ -179,8 +188,7 @@ impl Plugin for ApplicationsPlugin {
         self.entries.clear();
 
         let mut paths: Vec<std::path::PathBuf> =
-            freedesktop_desktop_entry::Iter::new(freedesktop_desktop_entry::default_paths())
-                .collect();
+            freedesktop_desktop_entry::Iter::new(data_dirs()).collect();
 
         paths.sort_by_key(path_name);
         paths.dedup_by_key(|path| path_name(path));


### PR DESCRIPTION
This PR implements a bunch of fixes around the applications plugin. This aligns the applications plugin closer with the [freedesktop desktop entry specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html). Furhtermore it fixes #110.

This PR includes:
- Hiding desktop entries based on the following logic:
   - Type has to be "Application"
   - Hidden has to be false or unset
   - NoDisplay has to be false or unset
   - the XDG_CURRENT_DESKTOP has to be in OnlyShowIn and not in NotShowIn
- Terminal desktop entries are now opened in the first terminal emulator that is found on the system (fixes things like btop not being able to launch)