### PR TITLE
💄 display bars to visualize cpu core usage

### DIFF
--- a/client/src/plugin/resource_monitor/cpu.rs
+++ b/client/src/plugin/resource_monitor/cpu.rs
@@ -28,22 +28,36 @@ impl Plugin for CpuPlugin {
 
     fn update_entries(&mut self) -> anyhow::Result<()> {
         self.sysinfo.refresh_cpu();
-
         self.entries.clear();
+
+        let mut core_usages: String = format!(
+            "{}% – {} Cores:",
+            self.sysinfo.global_cpu_info().cpu_usage() as i32,
+            self.sysinfo.cpus().len()
+        );
+
         for cpu_core in self.sysinfo.cpus() {
-            self.entries.push(crate::model::Entry {
-                id: cpu_core.name().to_string(),
-                title: format!(
-                    "{}: {}% {}MHz",
-                    cpu_core.name(),
-                    cpu_core.cpu_usage() as i32,
-                    cpu_core.frequency()
-                ),
-                action: String::from(""),
-                meta: String::from("Resource Monitor CPU"),
-                command: None,
-            });
+            let core_usage = match cpu_core.cpu_usage() as i32 {
+                0..=12 => " ▁",
+                13..=25 => " ▂",
+                26..=37 => " ▃",
+                38..=50 => " ▄",
+                51..=62 => " ▅",
+                63..=75 => " ▆",
+                76..=87 => " ▇",
+                _ => " █",
+            };
+
+            core_usages.push_str(core_usage);
         }
+
+        self.entries.push(crate::model::Entry {
+            id: "cpu".into(),
+            title: core_usages,
+            action: String::from(""),
+            meta: String::from("Resource Monitor CPU"),
+            command: None,
+        });
 
         Ok(())
     }


### PR DESCRIPTION
This PR changes the CPU resource monitor plugin to visualize its cores as bars in one line instead of having a line per core. This resolves #104 and fixes #114.

![2024-04-01-193340_hyprshot](https://github.com/friedow/centerpiece/assets/17351844/7fde2618-5156-4959-bca0-1723ca4ad945)
