### PR TITLE
return false when file_name cannot convert to str

### DIFF
--- a/services/index-git-repositories/src/main.rs
+++ b/services/index-git-repositories/src/main.rs
@@ -10,7 +10,9 @@ fn main() {
         .strict()
         .hidden()
         .custom_filter(|dir| {
-            let name = dir.file_name().to_str().unwrap();
+            let Some(name) = dir.file_name().to_str() else {
+                return false;
+            };
             if name == ".git" {
                 return true;
             }


### PR DESCRIPTION
Since to_str will not fail when the input is ".git" and that input is the only input that matters to us, we can avoid crashing the daemon when to_str returns none.