### PR TITLE
🐛 filter empty plugins for calculating scroll offset

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -381,6 +381,7 @@ impl Centerpiece {
             Some(active_entry_id) => self
                 .plugins
                 .iter()
+                .filter(|plugin| plugin.entries.len() > 0)
                 .position(|plugin| {
                     plugin
                         .entries


### PR DESCRIPTION
This fixes the scrolling issue below #114.