### PR TITLE
🐛 fix initial sorting in a bunch of plugins

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -449,7 +449,10 @@ impl Centerpiece {
         self.scroll_to_selected_entry()
     }
 
-    fn register_plugin(&mut self, plugin: crate::model::Plugin) -> iced::Command<Message> {
+    fn register_plugin(&mut self, mut plugin: crate::model::Plugin) -> iced::Command<Message> {
+        let _ = plugin
+            .app_channel_out
+            .try_send(crate::model::PluginRequest::Search(self.query.clone()));
         self.plugins.push(plugin);
         self.plugins.sort_by(|a, b| b.priority.cmp(&a.priority));
         iced::Command::none()

--- a/client/src/plugin/applications.rs
+++ b/client/src/plugin/applications.rs
@@ -172,8 +172,7 @@ impl Plugin for ApplicationsPlugin {
             .filter_map(|path| to_entry(path, terminal_command.clone()))
             .collect();
 
-        self.entries.sort();
-        self.entries.dedup();
+        self.sort();
 
         Ok(())
     }

--- a/client/src/plugin/brave/bookmarks.rs
+++ b/client/src/plugin/brave/bookmarks.rs
@@ -38,6 +38,7 @@ impl Plugin for BookmarksPlugin {
             .map(|bookmark| bookmark.into())
             .collect();
 
+        self.sort();
         Ok(())
     }
 

--- a/client/src/plugin/brave/progressive_web_apps.rs
+++ b/client/src/plugin/brave/progressive_web_apps.rs
@@ -47,6 +47,7 @@ impl Plugin for ProgressiveWebAppsPlugin {
             .map(|bookmark| bookmark.into())
             .collect();
 
+        self.sort();
         Ok(())
     }
 

--- a/client/src/plugin/utils.rs
+++ b/client/src/plugin/utils.rs
@@ -126,7 +126,7 @@ pub trait Plugin {
 
     fn sort(&mut self) {
         let mut entries = self.entries();
-        entries.sort_by_key(|entry| entry.title.clone());
+        entries.sort_by_key(|entry| entry.title.clone().to_lowercase());
         self.set_entries(entries)
     }
 
@@ -135,9 +135,6 @@ pub trait Plugin {
         query: &str,
         plugin_channel_out: &mut iced::futures::channel::mpsc::Sender<crate::Message>,
     ) -> anyhow::Result<()> {
-        if query.is_empty() {
-            self.sort();
-        }
         let filtered_entries = self
             .entries()
             .into_iter()


### PR DESCRIPTION
This sorts entries in the following plugins after they are updated:
- applications
- sway-windows
- brave-bookmarks
- brave-progressive-web-apps

This fixes the initial sorting on those plugins. Furthermore, this removes the unnecessary sorting on an empty query and it fixes lower vs uppercase sorting problems.

This fixes #122. 