### PR TITLE
🐛 Change settings to be loaded only once from disk

### DIFF
--- a/client/src/component/entry.rs
+++ b/client/src/component/entry.rs
@@ -41,7 +41,7 @@ impl iced::widget::container::StyleSheet for Style {
     type Style = iced::Theme;
 
     fn appearance(&self, _style: &Self::Style) -> iced::widget::container::Appearance {
-        let color_settings = crate::settings::Settings::new();
+        let color_settings = crate::settings::Settings::get_or_init();
 
         iced::widget::container::Appearance {
             background: None,

--- a/client/src/component/query_input.rs
+++ b/client/src/component/query_input.rs
@@ -49,22 +49,22 @@ impl iced::widget::text_input::StyleSheet for Style {
     }
 
     fn placeholder_color(&self, _style: &Self::Style) -> iced::Color {
-        let color_settings = crate::settings::Settings::new();
+        let color_settings = crate::settings::Settings::get_or_init();
         crate::settings::hexcolor(&color_settings.color.surface)
     }
 
     fn value_color(&self, _style: &Self::Style) -> iced::Color {
-        let color_settings = crate::settings::Settings::new();
+        let color_settings = crate::settings::Settings::get_or_init();
         crate::settings::hexcolor(&color_settings.color.text)
     }
 
     fn disabled_color(&self, _style: &Self::Style) -> iced::Color {
-        let color_settings = crate::settings::Settings::new();
+        let color_settings = crate::settings::Settings::get_or_init();
         crate::settings::hexcolor(&color_settings.color.surface)
     }
 
     fn selection_color(&self, _style: &Self::Style) -> iced::Color {
-        let color_settings = crate::settings::Settings::new();
+        let color_settings = crate::settings::Settings::get_or_init();
         crate::settings::hexcolor(&color_settings.color.surface)
     }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -529,7 +529,7 @@ impl iced::application::StyleSheet for SandboxStyle {
     type Style = iced::Theme;
 
     fn appearance(&self, _style: &Self::Style) -> iced::application::Appearance {
-        let color_settings = crate::settings::Settings::new();
+        let color_settings = crate::settings::Settings::get_or_init();
 
         iced::application::Appearance {
             background_color: iced::Color::TRANSPARENT,
@@ -543,7 +543,7 @@ impl iced::widget::container::StyleSheet for ApplicationWrapperStyle {
     type Style = iced::Theme;
 
     fn appearance(&self, _style: &Self::Style) -> iced::widget::container::Appearance {
-        let color_settings = crate::settings::Settings::new();
+        let color_settings = crate::settings::Settings::get_or_init();
         iced::widget::container::Appearance {
             background: Some(iced::Background::Color(settings::hexcolor(
                 &color_settings.color.background,
@@ -561,7 +561,7 @@ impl iced::widget::scrollable::StyleSheet for ScrollableStyle {
     type Style = iced::Theme;
 
     fn active(&self, _style: &Self::Style) -> iced::widget::scrollable::Scrollbar {
-        let color_settings = crate::settings::Settings::new();
+        let color_settings = crate::settings::Settings::get_or_init();
         iced::widget::scrollable::Scrollbar {
             background: None,
             border_radius: iced::BorderRadius::from(0.),
@@ -581,7 +581,7 @@ impl iced::widget::scrollable::StyleSheet for ScrollableStyle {
         _style: &Self::Style,
         _is_mouse_over_scrollbar: bool,
     ) -> iced::widget::scrollable::Scrollbar {
-        let color_settings = crate::settings::Settings::new();
+        let color_settings = crate::settings::Settings::get_or_init();
         iced::widget::scrollable::Scrollbar {
             background: None,
             border_radius: iced::BorderRadius::from(0.),

--- a/client/src/settings.rs
+++ b/client/src/settings.rs
@@ -1,5 +1,6 @@
 use hex_color::HexColor;
 use serde::Deserialize;
+use std::sync::OnceLock;
 
 pub fn hexcolor(color: &str) -> iced::Color {
     let hex_col = HexColor::parse(color).unwrap_or_else(|_| {
@@ -326,6 +327,11 @@ impl Settings {
             panic!();
         }
         config_result.unwrap()
+    }
+
+    pub fn get_or_init() -> &'static Self {
+        static SETTINGS: OnceLock<Settings> = OnceLock::new();
+        SETTINGS.get_or_init(Self::new)
     }
 }
 


### PR DESCRIPTION
Add the `get_or_init` function to `[Settings]` that will cache the
result in memory once it reads the settings file from disk.
