### PR TITLE
🔨 Update crane library instantiation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
       inherit (cargoTOML.workspace.package) version;
       pname = "centerpiece";
 
-      craneLib = crane.lib.${system};
+      craneLib = crane.mkLib nixpkgs.legacyPackages.${system};
       fontFilter = path: _type: builtins.match ".*ttf$" path != null;
       configFilter = path: _type: builtins.match ".*config.yml$" path != null;
       assetOrCargo =


### PR DESCRIPTION
Update crane library instantiation from the now deprecated invocation.

Reference: https://github.com/ipetkov/crane/releases/tag/v0.17.0
