### PR TITLE
➖ Remove nixpkgs follow for crane input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     home-manager.url = "github:nix-community/home-manager";
     treefmt-nix.url = "github:numtide/treefmt-nix/";
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
   };
 
   outputs =


### PR DESCRIPTION
Remove nixpkgs follow for `crane` flake inputs.

`crane` doesn't depend on `nixpkgs` anymore.
