### PR TITLE
🐛 fix centerpiece not being an overlay in some wayland WMs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,7 @@ dependencies = [
  "hex_color",
  "iced",
  "iced_layershell",
+ "iced_runtime",
  "log",
  "networkmanager",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,20 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "calloop"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
+dependencies = [
+ "bitflags 2.6.0",
+ "log",
+ "polling",
+ "rustix",
+ "slab",
+ "thiserror",
+]
+
+[[package]]
+name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
@@ -593,11 +607,23 @@ dependencies = [
 
 [[package]]
 name = "calloop-wayland-source"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
+dependencies = [
+ "calloop 0.12.4",
+ "rustix",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "calloop",
+ "calloop 0.13.0",
  "rustix",
  "wayland-backend",
  "wayland-client",
@@ -628,6 +654,7 @@ dependencies = [
  "freedesktop-desktop-entry",
  "hex_color",
  "iced",
+ "iced_layershell",
  "log",
  "networkmanager",
  "serde",
@@ -1051,6 +1078,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "data-url"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "font-types"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,7 +1441,7 @@ checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
 dependencies = [
  "fontconfig-parser",
  "log",
- "memmap2",
+ "memmap2 0.9.5",
  "slotmap",
  "tinyvec",
  "ttf-parser 0.20.0",
@@ -1387,7 +1455,7 @@ checksum = "e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770"
 dependencies = [
  "fontconfig-parser",
  "log",
- "memmap2",
+ "memmap2 0.9.5",
  "slotmap",
  "tinyvec",
  "ttf-parser 0.21.1",
@@ -1916,6 +1984,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "iced_layershell"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f5e7be8fe8018bf5434afa6fcfa64fbb2131510d552d4523855bb20d9a79c5"
+dependencies = [
+ "futures",
+ "iced",
+ "iced_core",
+ "iced_futures",
+ "iced_graphics",
+ "iced_layershell_macros",
+ "iced_renderer",
+ "iced_runtime",
+ "layershellev",
+ "log",
+ "thiserror",
+ "tracing",
+ "window_clipboard",
+]
+
+[[package]]
+name = "iced_layershell_macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999b41f42992ea760bf65f8b179d1832d30ac113fdf843a50ee57a2700d1ad4f"
+dependencies = [
+ "darling",
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "iced_renderer"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2115,12 @@ dependencies = [
  "window_clipboard",
  "winit",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "ignore"
@@ -2171,6 +2279,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "layershellev"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7933548cb009d08c9016dc9f1f49a1e6f32d50f962c09a6dc418b2d6240eb064"
+dependencies = [
+ "bitflags 2.6.0",
+ "log",
+ "raw-window-handle",
+ "smithay-client-toolkit 0.18.1",
+ "tempfile",
+ "thiserror",
+ "waycrate_xkbkeycode",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-cursor",
+ "wayland-protocols 0.32.4",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr 0.3.4",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,10 +2443,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "darling_core",
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmap2"
@@ -3082,6 +3244,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3408,8 +3581,8 @@ checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
 dependencies = [
  "ab_glyph",
  "log",
- "memmap2",
- "smithay-client-toolkit",
+ "memmap2 0.9.5",
+ "smithay-client-toolkit 0.19.2",
  "tiny-skia",
 ]
 
@@ -3596,25 +3769,53 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.19.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
 dependencies = [
  "bitflags 2.6.0",
- "calloop",
- "calloop-wayland-source",
+ "bytemuck",
+ "calloop 0.12.4",
+ "calloop-wayland-source 0.2.0",
  "cursor-icon",
  "libc",
  "log",
- "memmap2",
+ "memmap2 0.9.5",
+ "pkg-config",
  "rustix",
  "thiserror",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-wlr",
+ "wayland-protocols 0.31.2",
+ "wayland-protocols-wlr 0.2.0",
+ "wayland-scanner",
+ "xkbcommon",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.6.0",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2 0.9.5",
+ "rustix",
+ "thiserror",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols 0.32.4",
+ "wayland-protocols-wlr 0.3.4",
  "wayland-scanner",
  "xkeysym",
 ]
@@ -3626,7 +3827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846"
 dependencies = [
  "libc",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2",
  "wayland-backend",
 ]
 
@@ -3654,7 +3855,7 @@ dependencies = [
  "foreign-types",
  "js-sys",
  "log",
- "memmap2",
+ "memmap2 0.9.5",
  "objc2",
  "objc2-foundation",
  "objc2-quartz-core",
@@ -3916,9 +4117,9 @@ checksum = "1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4394,6 +4595,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "waycrate_xkbkeycode"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe95e9400409031c29521001f26ee9c9b99232995378aa2ef4f15cbedb42d90"
+dependencies = [
+ "bitflags 2.6.0",
+ "log",
+ "memmap2 0.9.5",
+ "smol_str",
+ "wayland-backend",
+ "wayland-client",
+ "xkbcommon-dl",
+]
+
+[[package]]
 name = "wayland-backend"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4443,6 +4659,18 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
 version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b5755d77ae9040bb872a25026555ce4cb0ae75fd923e90d25fba07d81057de0"
@@ -4450,6 +4678,19 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40dd9d2f7f2713724d84b920d6f73ff878f6a353712942f75f78f4dadb72886"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.32.4",
  "wayland-scanner",
 ]
 
@@ -4462,7 +4703,20 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.32.4",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.31.2",
  "wayland-scanner",
 ]
 
@@ -4475,7 +4729,7 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.32.4",
  "wayland-scanner",
 ]
 
@@ -4931,7 +5185,7 @@ dependencies = [
  "bitflags 2.6.0",
  "block2",
  "bytemuck",
- "calloop",
+ "calloop 0.13.0",
  "cfg_aliases 0.2.1",
  "concurrent-queue",
  "core-foundation 0.9.4",
@@ -4940,7 +5194,7 @@ dependencies = [
  "dpi",
  "js-sys",
  "libc",
- "memmap2",
+ "memmap2 0.9.5",
  "ndk",
  "objc2",
  "objc2-app-kit",
@@ -4953,7 +5207,7 @@ dependencies = [
  "redox_syscall 0.4.1",
  "rustix",
  "sctk-adwaita",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2",
  "smol_str",
  "tracing",
  "unicode-segmentation",
@@ -4961,7 +5215,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.32.4",
  "wayland-protocols-plasma",
  "web-sys",
  "web-time",
@@ -5044,6 +5298,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "xkbcommon"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e"
+dependencies = [
+ "libc",
+ "memmap2 0.8.0",
+ "xkeysym",
+]
+
+[[package]]
 name = "xkbcommon-dl"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5061,6 +5326,9 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -406,7 +406,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -562,7 +562,7 @@ checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -579,20 +579,6 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "calloop"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
-dependencies = [
- "bitflags 2.6.0",
- "log",
- "polling",
- "rustix",
- "slab",
- "thiserror",
-]
-
-[[package]]
-name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
@@ -606,15 +592,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "calloop-wayland-source"
-version = "0.2.0"
+name = "calloop"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
+checksum = "a1ead1e1514bce44c0f40e027899fbc595907fc112635bed21b3b5d975c0a5e7"
 dependencies = [
- "calloop 0.12.4",
+ "bitflags 2.6.0",
+ "polling",
  "rustix",
- "wayland-backend",
- "wayland-client",
+ "slab",
+ "tracing",
 ]
 
 [[package]]
@@ -624,6 +611,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop 0.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a7a1dbbe026a55ef47a500b123af5a9a0914520f061d467914cf21be95daf"
+dependencies = [
+ "calloop 0.14.1",
  "rustix",
  "wayland-backend",
  "wayland-client",
@@ -736,7 +735,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1098,7 +1097,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1109,7 +1108,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1291,7 +1290,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1441,7 +1440,7 @@ checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
 dependencies = [
  "fontconfig-parser",
  "log",
- "memmap2 0.9.5",
+ "memmap2",
  "slotmap",
  "tinyvec",
  "ttf-parser 0.20.0",
@@ -1455,7 +1454,7 @@ checksum = "e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770"
 dependencies = [
  "fontconfig-parser",
  "log",
- "memmap2 0.9.5",
+ "memmap2",
  "slotmap",
  "tinyvec",
  "ttf-parser 0.21.1",
@@ -1479,7 +1478,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1503,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1518,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1528,15 +1527,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1546,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -1565,32 +1564,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1985,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "iced_layershell"
-version = "0.9.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f5e7be8fe8018bf5434afa6fcfa64fbb2131510d552d4523855bb20d9a79c5"
+checksum = "c7b5cc18818b5f07b7e4e5742d47b13e59f33d1e6f4d3c3c3eeb726481cc05e3"
 dependencies = [
  "futures",
  "iced",
@@ -2006,15 +2005,15 @@ dependencies = [
 
 [[package]]
 name = "iced_layershell_macros"
-version = "0.9.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999b41f42992ea760bf65f8b179d1832d30ac113fdf843a50ee57a2700d1ad4f"
+checksum = "f778284314281b4994c0ac45b8ad654fa87266956e1814d1a00bd9a2f6b3141f"
 dependencies = [
  "darling",
  "manyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2280,23 +2279,24 @@ dependencies = [
 
 [[package]]
 name = "layershellev"
-version = "0.9.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7933548cb009d08c9016dc9f1f49a1e6f32d50f962c09a6dc418b2d6240eb064"
+checksum = "072e6fb98dd0efcdbcdccdf2a81940b7732d56967b36e08e587c5cf9c34fc61b"
 dependencies = [
  "bitflags 2.6.0",
+ "calloop 0.14.1",
+ "calloop-wayland-source 0.4.0",
  "log",
  "raw-window-handle",
- "smithay-client-toolkit 0.18.1",
  "tempfile",
  "thiserror",
  "waycrate_xkbkeycode",
  "wayland-backend",
  "wayland-client",
  "wayland-cursor",
- "wayland-protocols 0.32.4",
+ "wayland-protocols",
  "wayland-protocols-misc",
- "wayland-protocols-wlr 0.3.4",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]
@@ -2452,7 +2452,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2471,15 +2471,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memmap2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memmap2"
@@ -2651,7 +2642,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2691,7 +2682,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3019,7 +3010,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3118,7 +3109,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3153,7 +3144,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3256,9 +3247,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -3581,8 +3572,8 @@ checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
 dependencies = [
  "ab_glyph",
  "log",
- "memmap2 0.9.5",
- "smithay-client-toolkit 0.19.2",
+ "memmap2",
+ "smithay-client-toolkit",
  "tiny-skia",
 ]
 
@@ -3609,7 +3600,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3652,7 +3643,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3769,34 +3760,6 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
-dependencies = [
- "bitflags 2.6.0",
- "bytemuck",
- "calloop 0.12.4",
- "calloop-wayland-source 0.2.0",
- "cursor-icon",
- "libc",
- "log",
- "memmap2 0.9.5",
- "pkg-config",
- "rustix",
- "thiserror",
- "wayland-backend",
- "wayland-client",
- "wayland-csd-frame",
- "wayland-cursor",
- "wayland-protocols 0.31.2",
- "wayland-protocols-wlr 0.2.0",
- "wayland-scanner",
- "xkbcommon",
- "xkeysym",
-]
-
-[[package]]
-name = "smithay-client-toolkit"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
@@ -3807,15 +3770,15 @@ dependencies = [
  "cursor-icon",
  "libc",
  "log",
- "memmap2 0.9.5",
+ "memmap2",
  "rustix",
  "thiserror",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols 0.32.4",
- "wayland-protocols-wlr 0.3.4",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
 ]
@@ -3827,7 +3790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846"
 dependencies = [
  "libc",
- "smithay-client-toolkit 0.19.2",
+ "smithay-client-toolkit",
  "wayland-backend",
 ]
 
@@ -3855,7 +3818,7 @@ dependencies = [
  "foreign-types",
  "js-sys",
  "log",
- "memmap2 0.9.5",
+ "memmap2",
  "objc2",
  "objc2-foundation",
  "objc2-quartz-core",
@@ -4076,9 +4039,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4154,7 +4117,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4267,6 +4230,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4280,7 +4244,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4534,7 +4498,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -4568,7 +4532,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4596,13 +4560,13 @@ dependencies = [
 
 [[package]]
 name = "waycrate_xkbkeycode"
-version = "0.9.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe95e9400409031c29521001f26ee9c9b99232995378aa2ef4f15cbedb42d90"
+checksum = "3a7bd055785a92d468d4be98c9d0b1929ed17bf190c3a36d9878b991a05f8800"
 dependencies = [
  "bitflags 2.6.0",
  "log",
- "memmap2 0.9.5",
+ "memmap2",
  "smol_str",
  "wayland-backend",
  "wayland-client",
@@ -4659,18 +4623,6 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
 version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b5755d77ae9040bb872a25026555ce4cb0ae75fd923e90d25fba07d81057de0"
@@ -4690,7 +4642,7 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.4",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -4703,20 +4655,7 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.4",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-wlr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -4729,7 +4668,7 @@ dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.4",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -5194,7 +5133,7 @@ dependencies = [
  "dpi",
  "js-sys",
  "libc",
- "memmap2 0.9.5",
+ "memmap2",
  "ndk",
  "objc2",
  "objc2-app-kit",
@@ -5207,7 +5146,7 @@ dependencies = [
  "redox_syscall 0.4.1",
  "rustix",
  "sctk-adwaita",
- "smithay-client-toolkit 0.19.2",
+ "smithay-client-toolkit",
  "smol_str",
  "tracing",
  "unicode-segmentation",
@@ -5215,7 +5154,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.4",
+ "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
  "web-time",
@@ -5298,17 +5237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xkbcommon"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e"
-dependencies = [
- "libc",
- "memmap2 0.8.0",
- "xkeysym",
-]
-
-[[package]]
 name = "xkbcommon-dl"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5326,9 +5254,6 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "xml-rs"
@@ -5395,7 +5320,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
  "zvariant_utils",
 ]
 
@@ -5434,7 +5359,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5459,7 +5384,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
  "zvariant_utils",
 ]
 
@@ -5471,5 +5396,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,6 +25,7 @@ serde_yaml = "0.9.34"
 
 # application window
 iced = { version = "0.13.1", features = ["svg"] }
+iced_layershell = "0.9.0"
 
 hex_color = "3"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -58,3 +58,4 @@ dbus = "0.9.7"
 
 # firefox bookmarks
 serde_ini = "0.2.0"
+iced_runtime = "0.13.2"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,7 +25,7 @@ serde_yaml = "0.9.34"
 
 # application window
 iced = { version = "0.13.1", features = ["svg"] }
-iced_layershell = "0.9.0"
+iced_layershell = "0.9.4"
 
 hex_color = "3"
 

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use iced::Theme;
 use iced_layershell::to_layer_message;
 use iced_layershell::Application;
+use iced_runtime::Action;
 mod cli;
 mod component;
 mod model;
@@ -86,7 +87,7 @@ impl Application for Centerpiece {
                     }
                     iced::keyboard::Event::KeyReleased { key, .. } => {
                         if key == iced::keyboard::Key::Named(iced::keyboard::key::Named::Escape) {
-                            return iced::window::get_latest().and_then(iced::window::close);
+                            return iced_runtime::task::effect(Action::Exit);
                         }
                         iced::Task::none()
                     }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,12 +1,15 @@
 use clap::Parser;
 
+use iced::Theme;
+use iced_layershell::to_layer_message;
+use iced_layershell::Application;
 mod cli;
 mod component;
 mod model;
 mod plugin;
 mod settings;
 
-pub fn main() -> iced::Result {
+pub fn main() -> Result<(), iced_layershell::Error> {
     let args = crate::cli::CliArgs::parse();
     crate::settings::Settings::try_from(args).unwrap_or_else(|_| {
         eprintln!("There is an issue with the settings, please check the configuration file.");
@@ -14,20 +17,10 @@ pub fn main() -> iced::Result {
     });
 
     simple_logger::init_with_level(log::Level::Info).unwrap();
-    iced::application("Centerpiece", update, view)
-        .decorations(false)
-        .level(iced::window::Level::AlwaysOnTop)
-        .position(iced::window::Position::Centered)
-        .resizable(false)
-        .settings(settings())
-        .style(style)
-        .subscription(subscription)
-        .theme(theme)
-        .transparent(true)
-        .window_size([650., 380.])
-        .run_with(Centerpiece::new)
+    Centerpiece::run(settings())
 }
 
+#[to_layer_message]
 #[derive(Debug, Clone)]
 pub enum Message {
     Loaded,
@@ -47,274 +40,283 @@ struct Centerpiece {
 
 pub const APP_ID: &str = "centerpiece";
 
-fn update(centerpiece: &mut Centerpiece, message: Message) -> iced::Task<Message> {
-    match message {
-        Message::Loaded => focus_search_input(),
+impl Application for Centerpiece {
+    type Executor = iced::executor::Default;
+    type Theme = Theme;
+    type Flags = ();
+    type Message = Message;
+    fn namespace(&self) -> String {
+        "centerpiece".to_string()
+    }
+    fn new(_flags: Self::Flags) -> (Self, iced::Task<Self::Message>) {
+        Self::new()
+    }
+    fn update(&mut self, message: Message) -> iced::Task<Message> {
+        match message {
+            Message::Loaded => focus_search_input(),
 
-        Message::Search(input) => centerpiece.search(input),
+            Message::Search(input) => self.search(input),
 
-        Message::Event(event) => match event {
-            iced::Event::Keyboard(event) => match event {
-                iced::keyboard::Event::KeyPressed { key, modifiers, .. } => {
-                    if let iced::keyboard::Modifiers::CTRL = modifiers {
-                        return match key.as_ref() {
-                            iced::keyboard::Key::Character("j") => centerpiece.select_next_entry(),
-                            iced::keyboard::Key::Character("k") => {
-                                centerpiece.select_previous_entry()
+            Message::Event(event) => match event {
+                iced::Event::Keyboard(event) => match event {
+                    iced::keyboard::Event::KeyPressed { key, modifiers, .. } => {
+                        if let iced::keyboard::Modifiers::CTRL = modifiers {
+                            return match key.as_ref() {
+                                iced::keyboard::Key::Character("j") => self.select_next_entry(),
+                                iced::keyboard::Key::Character("k") => self.select_previous_entry(),
+                                iced::keyboard::Key::Character("n") => self.select_next_plugin(),
+                                iced::keyboard::Key::Character("p") => {
+                                    self.select_previous_plugin()
+                                }
+                                _ => iced::Task::none(),
+                            };
+                        }
+                        match key.as_ref() {
+                            iced::keyboard::Key::Named(iced::keyboard::key::Named::ArrowUp) => {
+                                self.select_previous_entry()
                             }
-                            iced::keyboard::Key::Character("n") => centerpiece.select_next_plugin(),
-                            iced::keyboard::Key::Character("p") => {
-                                centerpiece.select_previous_plugin()
+                            iced::keyboard::Key::Named(iced::keyboard::key::Named::ArrowDown) => {
+                                self.select_next_entry()
+                            }
+                            iced::keyboard::Key::Named(iced::keyboard::key::Named::Enter) => {
+                                self.activate_selected_entry().unwrap_or(iced::Task::none())
                             }
                             _ => iced::Task::none(),
-                        };
-                    }
-                    match key.as_ref() {
-                        iced::keyboard::Key::Named(iced::keyboard::key::Named::ArrowUp) => {
-                            centerpiece.select_previous_entry()
                         }
-                        iced::keyboard::Key::Named(iced::keyboard::key::Named::ArrowDown) => {
-                            centerpiece.select_next_entry()
-                        }
-                        iced::keyboard::Key::Named(iced::keyboard::key::Named::Enter) => {
-                            centerpiece
-                                .activate_selected_entry()
-                                .unwrap_or(iced::Task::none())
-                        }
-                        _ => iced::Task::none(),
                     }
-                }
-                iced::keyboard::Event::KeyReleased { key, .. } => {
-                    if key == iced::keyboard::Key::Named(iced::keyboard::key::Named::Escape) {
-                        return iced::window::get_latest().and_then(iced::window::close);
+                    iced::keyboard::Event::KeyReleased { key, .. } => {
+                        if key == iced::keyboard::Key::Named(iced::keyboard::key::Named::Escape) {
+                            return iced::window::get_latest().and_then(iced::window::close);
+                        }
+                        iced::Task::none()
                     }
-                    iced::Task::none()
-                }
+
+                    _ => iced::Task::none(),
+                },
+
+                iced::Event::Mouse(iced::mouse::Event::ButtonPressed(
+                    iced::mouse::Button::Left,
+                )) => focus_search_input(),
 
                 _ => iced::Task::none(),
             },
 
-            iced::Event::Mouse(iced::mouse::Event::ButtonPressed(iced::mouse::Button::Left)) => {
-                focus_search_input()
-            }
+            Message::FontLoaded(_) => iced::Task::none(),
 
+            Message::RegisterPlugin(plugin) => self.register_plugin(plugin),
+
+            Message::UpdateEntries(plugin_id, entries) => self.update_entries(plugin_id, entries),
+
+            Message::Exit => iced::window::get_latest().and_then(iced::window::close),
             _ => iced::Task::none(),
-        },
-
-        Message::FontLoaded(_) => iced::Task::none(),
-
-        Message::RegisterPlugin(plugin) => centerpiece.register_plugin(plugin),
-
-        Message::UpdateEntries(plugin_id, entries) => {
-            centerpiece.update_entries(plugin_id, entries)
         }
-
-        Message::Exit => iced::window::get_latest().and_then(iced::window::close),
     }
-}
 
-fn view(centerpiece: &Centerpiece) -> iced::Element<Message> {
-    let entries = centerpiece.entries();
+    fn view(&self) -> iced::Element<Message> {
+        let entries = self.entries();
 
-    let mut lines = iced::widget::column![];
-    let mut divider_added = true;
-    let mut header_added = false;
-    let mut next_entry_index_to_add = centerpiece.active_entry_index;
+        let mut lines = iced::widget::column![];
+        let mut divider_added = true;
+        let mut header_added = false;
+        let mut next_entry_index_to_add = self.active_entry_index;
 
-    for lines_added in 0..11 {
-        if next_entry_index_to_add >= entries.len() {
-            break;
-        }
-
-        let mut plugin_to_add = None;
-        let mut last_plugin_start_index = 0;
-        for plugin in centerpiece.plugins.iter() {
-            if last_plugin_start_index == next_entry_index_to_add {
-                plugin_to_add = Some(plugin);
+        for lines_added in 0..11 {
+            if next_entry_index_to_add >= entries.len() {
+                break;
             }
-            last_plugin_start_index += plugin.entries.len();
-        }
 
-        if !divider_added && plugin_to_add.is_some() {
-            lines = lines.push(component::divider::view());
-            divider_added = true;
-            continue;
-        }
+            let mut plugin_to_add = None;
+            let mut last_plugin_start_index = 0;
+            for plugin in self.plugins.iter() {
+                if last_plugin_start_index == next_entry_index_to_add {
+                    plugin_to_add = Some(plugin);
+                }
+                last_plugin_start_index += plugin.entries.len();
+            }
 
-        if !header_added && plugin_to_add.is_some() {
-            lines = lines.push(component::plugin_header::view(plugin_to_add.unwrap()));
-            header_added = true;
-            continue;
-        } else if lines_added == 0 {
+            if !divider_added && plugin_to_add.is_some() {
+                lines = lines.push(component::divider::view());
+                divider_added = true;
+                continue;
+            }
+
+            if !header_added && plugin_to_add.is_some() {
+                lines = lines.push(component::plugin_header::view(plugin_to_add.unwrap()));
+                header_added = true;
+                continue;
+            } else if lines_added == 0 {
+                lines = lines.push(component::entry::view(
+                    entries[next_entry_index_to_add - 1],
+                    false,
+                ));
+            }
+
             lines = lines.push(component::entry::view(
-                entries[next_entry_index_to_add - 1],
-                false,
+                entries[next_entry_index_to_add],
+                next_entry_index_to_add == self.active_entry_index,
             ));
+            divider_added = false;
+            header_added = false;
+            next_entry_index_to_add += 1;
         }
 
-        lines = lines.push(component::entry::view(
-            entries[next_entry_index_to_add],
-            next_entry_index_to_add == centerpiece.active_entry_index,
-        ));
-        divider_added = false;
-        header_added = false;
-        next_entry_index_to_add += 1;
+        iced::widget::container(iced::widget::column![
+            component::query_input::view(&self.query, !entries.is_empty()),
+            lines
+        ])
+        .style(|theme: &iced::Theme| {
+            let palette = theme.extended_palette();
+
+            iced::widget::container::Style {
+                background: Some(iced::Background::Color(palette.background.base.color)),
+                border: iced::Border::default().rounded(0.25 * crate::REM),
+                ..Default::default()
+            }
+        })
+        .padding(iced::padding::bottom(0.75 * crate::REM))
+        .into()
     }
 
-    iced::widget::container(iced::widget::column![
-        component::query_input::view(&centerpiece.query, !entries.is_empty()),
-        lines
-    ])
-    .style(|theme: &iced::Theme| {
-        let palette = theme.extended_palette();
+    fn subscription(&self) -> iced::Subscription<Message> {
+        let mut subscriptions = vec![iced::event::listen_with(
+            |event, _status, _id| match event {
+                iced::Event::Keyboard(iced::keyboard::Event::KeyPressed { .. }) => {
+                    Some(Message::Event(event))
+                }
+                iced::Event::Keyboard(iced::keyboard::Event::KeyReleased { .. }) => {
+                    Some(Message::Event(event))
+                }
+                iced::Event::Mouse(iced::mouse::Event::ButtonPressed(_)) => {
+                    Some(Message::Event(event))
+                }
+                _ => None,
+            },
+        )];
 
-        iced::widget::container::Style {
-            background: Some(iced::Background::Color(palette.background.base.color)),
-            border: iced::Border::default().rounded(0.25 * crate::REM),
-            ..Default::default()
+        let settings = crate::settings::Settings::get_or_init();
+
+        if settings.plugin.applications.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::applications::ApplicationsPlugin,
+            >());
         }
-    })
-    .padding(iced::padding::bottom(0.75 * crate::REM))
-    .into()
-}
 
-fn subscription(_centerpiece: &Centerpiece) -> iced::Subscription<Message> {
-    let mut subscriptions = vec![iced::event::listen_with(
-        |event, _status, _id| match event {
-            iced::Event::Keyboard(iced::keyboard::Event::KeyPressed { .. }) => {
-                Some(Message::Event(event))
-            }
-            iced::Event::Keyboard(iced::keyboard::Event::KeyReleased { .. }) => {
-                Some(Message::Event(event))
-            }
-            iced::Event::Mouse(iced::mouse::Event::ButtonPressed(_)) => Some(Message::Event(event)),
-            _ => None,
-        },
-    )];
+        if settings.plugin.brave_bookmarks.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::brave::bookmarks::BookmarksPlugin,
+            >());
+        }
 
-    let settings = crate::settings::Settings::get_or_init();
+        if settings.plugin.brave_progressive_web_apps.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::brave::progressive_web_apps::ProgressiveWebAppsPlugin,
+            >());
+        }
 
-    if settings.plugin.applications.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::applications::ApplicationsPlugin,
-        >());
+        if settings.plugin.brave_history.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::brave::history::HistoryPlugin,
+            >());
+        }
+
+        if settings.plugin.clock.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::clock::ClockPlugin,
+            >());
+        }
+
+        if settings.plugin.firefox_bookmarks.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::firefox::bookmarks::BookmarksPlugin,
+            >());
+        }
+
+        if settings.plugin.firefox_history.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::firefox::history::HistoryPlugin,
+            >());
+        }
+
+        if settings.plugin.git_repositories.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::git_repositories::GitRepositoriesPlugin,
+            >());
+        }
+
+        if settings.plugin.gitmoji.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::gitmoji::GitmojiPlugin,
+            >());
+        }
+
+        if settings.plugin.resource_monitor_battery.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::resource_monitor::battery::BatteryPlugin,
+            >());
+        }
+
+        if settings.plugin.resource_monitor_cpu.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::resource_monitor::cpu::CpuPlugin,
+            >());
+        }
+
+        if settings.plugin.resource_monitor_disks.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::resource_monitor::disks::DisksPlugin,
+            >());
+        }
+
+        if settings.plugin.resource_monitor_memory.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::resource_monitor::memory::MemoryPlugin,
+            >());
+        }
+
+        if settings.plugin.system.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::system::SystemPlugin,
+            >());
+        }
+
+        if settings.plugin.wifi.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<crate::plugin::wifi::WifiPlugin>());
+        }
+
+        if settings.plugin.sway_windows.enable {
+            subscriptions.push(crate::plugin::utils::spawn::<
+                crate::plugin::sway_windows::SwayWindowsPlugin,
+            >());
+        }
+
+        iced::Subscription::batch(subscriptions)
     }
 
-    if settings.plugin.brave_bookmarks.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::brave::bookmarks::BookmarksPlugin,
-        >());
+    fn theme(&self) -> iced::Theme {
+        let settings = crate::settings::Settings::get_or_init();
+        iced::Theme::custom(
+            "centerpiece theme".to_string(),
+            iced::theme::Palette {
+                background: crate::settings::hexcolor(&settings.color.background),
+                text: crate::settings::hexcolor(&settings.color.text),
+                primary: crate::settings::hexcolor(&settings.color.text),
+                success: crate::settings::hexcolor(&settings.color.text),
+                danger: crate::settings::hexcolor(&settings.color.text),
+            },
+        )
     }
 
-    if settings.plugin.brave_progressive_web_apps.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::brave::progressive_web_apps::ProgressiveWebAppsPlugin,
-        >());
-    }
+    fn style(&self, _theme: &iced::Theme) -> iced_layershell::Appearance {
+        let color_settings = crate::settings::Settings::get_or_init();
 
-    if settings.plugin.brave_history.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::brave::history::HistoryPlugin,
-        >());
-    }
-
-    if settings.plugin.clock.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::clock::ClockPlugin,
-        >());
-    }
-
-    if settings.plugin.firefox_bookmarks.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::firefox::bookmarks::BookmarksPlugin,
-        >());
-    }
-
-    if settings.plugin.firefox_history.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::firefox::history::HistoryPlugin,
-        >());
-    }
-
-    if settings.plugin.git_repositories.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::git_repositories::GitRepositoriesPlugin,
-        >());
-    }
-
-    if settings.plugin.gitmoji.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::gitmoji::GitmojiPlugin,
-        >());
-    }
-
-    if settings.plugin.resource_monitor_battery.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::resource_monitor::battery::BatteryPlugin,
-        >());
-    }
-
-    if settings.plugin.resource_monitor_cpu.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::resource_monitor::cpu::CpuPlugin,
-        >());
-    }
-
-    if settings.plugin.resource_monitor_disks.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::resource_monitor::disks::DisksPlugin,
-        >());
-    }
-
-    if settings.plugin.resource_monitor_memory.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::resource_monitor::memory::MemoryPlugin,
-        >());
-    }
-
-    if settings.plugin.system.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::system::SystemPlugin,
-        >());
-    }
-
-    if settings.plugin.wifi.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<crate::plugin::wifi::WifiPlugin>());
-    }
-
-    if settings.plugin.sway_windows.enable {
-        subscriptions.push(crate::plugin::utils::spawn::<
-            crate::plugin::sway_windows::SwayWindowsPlugin,
-        >());
-    }
-
-    iced::Subscription::batch(subscriptions)
-}
-
-fn theme(_centerpiece: &Centerpiece) -> iced::Theme {
-    let settings = crate::settings::Settings::get_or_init();
-    iced::Theme::custom(
-        "centerpiece theme".to_string(),
-        iced::theme::Palette {
-            background: crate::settings::hexcolor(&settings.color.background),
-            text: crate::settings::hexcolor(&settings.color.text),
-            primary: crate::settings::hexcolor(&settings.color.text),
-            success: crate::settings::hexcolor(&settings.color.text),
-            danger: crate::settings::hexcolor(&settings.color.text),
-        },
-    )
-}
-
-fn style(_centerpiece: &Centerpiece, _theme: &iced::Theme) -> iced::application::Appearance {
-    let color_settings = crate::settings::Settings::get_or_init();
-
-    iced::application::Appearance {
-        background_color: iced::Color::TRANSPARENT,
-        text_color: settings::hexcolor(&color_settings.color.text),
+        iced_layershell::Appearance {
+            background_color: iced::Color::TRANSPARENT,
+            text_color: settings::hexcolor(&color_settings.color.text),
+        }
     }
 }
 
-fn settings() -> iced_layershell::settings::Settings {
+fn settings() -> iced_layershell::settings::Settings<()> {
     iced_layershell::settings::Settings {
         id: Some(APP_ID.into()),
         default_font: iced::Font {
@@ -327,9 +329,9 @@ fn settings() -> iced_layershell::settings::Settings {
         layer_settings: iced_layershell::settings::LayerShellSettings {
             size: Some((400, 400)),
             anchor: iced_layershell::reexport::Anchor::Bottom
-                | iced_layershell::reexport::Anchor::Left
+                | iced_layershell::reexport::Anchor::Top
                 | iced_layershell::reexport::Anchor::Right
-                | iced_layershell::reexport::Anchor::Right,
+                | iced_layershell::reexport::Anchor::Left,
             ..Default::default()
         },
         ..Default::default()

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -108,7 +108,7 @@ impl Application for Centerpiece {
 
             Message::UpdateEntries(plugin_id, entries) => self.update_entries(plugin_id, entries),
 
-            Message::Exit => iced::window::get_latest().and_then(iced::window::close),
+            Message::Exit => iced_runtime::task::effect(Action::Exit),
             _ => iced::Task::none(),
         }
     }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -327,11 +327,10 @@ fn settings() -> iced_layershell::settings::Settings<()> {
         },
         default_text_size: iced::Pixels(crate::REM),
         layer_settings: iced_layershell::settings::LayerShellSettings {
-            size: Some((400, 400)),
-            anchor: iced_layershell::reexport::Anchor::Bottom
-                | iced_layershell::reexport::Anchor::Top
-                | iced_layershell::reexport::Anchor::Right
-                | iced_layershell::reexport::Anchor::Left,
+            size: Some((650, 380)),
+            layer: iced_layershell::reexport::Layer::Top,
+            anchor: iced_layershell::reexport::Anchor::Top,
+            margin: (200, 0, 0, 0),
             ..Default::default()
         },
         ..Default::default()

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -331,6 +331,7 @@ fn settings() -> iced_layershell::settings::Settings<()> {
             size: Some((650, 380)),
             layer: iced_layershell::reexport::Layer::Top,
             anchor: iced_layershell::reexport::Anchor::Top,
+            keyboard_interactivity: iced_layershell::reexport::KeyboardInteractivity::Exclusive,
             margin: (200, 0, 0, 0),
             ..Default::default()
         },

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -28,15 +28,6 @@ pub fn main() -> iced::Result {
         .run_with(Centerpiece::new)
 }
 
-#[derive(Debug, Clone, Copy)]
-enum WindowDirection {
-    Top,
-    Left,
-    Right,
-    Bottom,
-}
-
-#[iced_layershell::to_layer_message]
 #[derive(Debug, Clone)]
 pub enum Message {
     Loaded,
@@ -45,7 +36,6 @@ pub enum Message {
     FontLoaded(Result<(), iced::font::Error>),
     RegisterPlugin(model::Plugin),
     UpdateEntries(String, Vec<model::Entry>),
-    Direction(WindowDirection),
     Exit,
 }
 
@@ -119,44 +109,7 @@ fn update(centerpiece: &mut Centerpiece, message: Message) -> iced::Task<Message
             centerpiece.update_entries(plugin_id, entries)
         }
 
-        Message::Direction(direction) => match direction {
-            WindowDirection::Left => iced::task::Task::batch(vec![
-                iced::task::Task::done(Message::AnchorChange(
-                    iced_layershell::reexport::Anchor::Left
-                        | iced_layershell::reexport::Anchor::Top
-                        | iced_layershell::reexport::Anchor::Bottom,
-                )),
-                iced::task::Task::done(Message::SizeChange((400, 0))),
-            ]),
-            WindowDirection::Right => iced::task::Task::batch(vec![
-                iced::task::Task::done(Message::AnchorChange(
-                    iced_layershell::reexport::Anchor::Right
-                        | iced_layershell::reexport::Anchor::Top
-                        | iced_layershell::reexport::Anchor::Bottom,
-                )),
-                iced::task::Task::done(Message::SizeChange((400, 0))),
-            ]),
-            WindowDirection::Bottom => iced::task::Task::batch(vec![
-                iced::task::Task::done(Message::AnchorChange(
-                    iced_layershell::reexport::Anchor::Bottom
-                        | iced_layershell::reexport::Anchor::Left
-                        | iced_layershell::reexport::Anchor::Right,
-                )),
-                iced::task::Task::done(Message::SizeChange((0, 400))),
-            ]),
-            WindowDirection::Top => iced::task::Task::batch(vec![
-                iced::task::Task::done(Message::AnchorChange(
-                    iced_layershell::reexport::Anchor::Top
-                        | iced_layershell::reexport::Anchor::Left
-                        | iced_layershell::reexport::Anchor::Right,
-                )),
-                iced::task::Task::done(Message::SizeChange((0, 400))),
-            ]),
-        },
-
         Message::Exit => iced::window::get_latest().and_then(iced::window::close),
-
-        _ => unreachable!(),
     }
 }
 
@@ -372,12 +325,11 @@ fn settings() -> iced_layershell::settings::Settings {
         },
         default_text_size: iced::Pixels(crate::REM),
         layer_settings: iced_layershell::settings::LayerShellSettings {
-            size: Some((0, 400)),
-            exclusive_zone: 400,
+            size: Some((400, 400)),
             anchor: iced_layershell::reexport::Anchor::Bottom
                 | iced_layershell::reexport::Anchor::Left
+                | iced_layershell::reexport::Anchor::Right
                 | iced_layershell::reexport::Anchor::Right,
-            start_mode,
             ..Default::default()
         },
         ..Default::default()

--- a/client/src/settings.rs
+++ b/client/src/settings.rs
@@ -343,7 +343,7 @@ impl Settings {
         let settings: Settings = config_result.unwrap();
 
         #[allow(deprecated)]
-        if settings.color.surface != String::from("deprecated") {
+        if settings.color.surface != *"deprecated" {
             log::warn!("color.surface has been replaced by automatic shading of the background color in cernterpiece version 1.2.0. Please remove this field from your configuration.")
         }
 


### PR DESCRIPTION
This PR fixes a bug where centerpiece was treated as a normal window and not a popup in some wayland window managers like [Niri](https://github.com/YaLTeR/niri). This was fixed by introducing [iced_layershell](https://crates.io/crates/iced-layershell) as a dependency which implements the [wayland layershell protocol](https://wayland.app/protocols/wlr-layer-shell-unstable-v1) for iced.

We had to revert the builder pattern for the iced application which was introduced with the upgrade to iced 0.13.x because iced_layershell does not support that yet.

Special thanks to @Decodetalkers for jumping in and helping me make this happen.

This resolves #188.