### PR TITLE
🌡️ CPU temperature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+
+[[package]]
 name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +665,7 @@ dependencies = [
  "sqlite",
  "swayipc",
  "sysinfo",
+ "systemstat",
 ]
 
 [[package]]
@@ -2497,6 +2504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +2612,16 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -4052,6 +4075,20 @@ dependencies = [
  "once_cell",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "systemstat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668a4db78b439df482c238f559e4ea869017f9e62ef0a059c8bfcd841a4df544"
+dependencies = [
+ "bytesize",
+ "lazy_static",
+ "libc",
+ "nom",
+ "time",
+ "winapi",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -59,3 +59,4 @@ dbus = "0.9.7"
 # firefox bookmarks
 serde_ini = "0.2.0"
 iced_runtime = "0.13.2"
+systemstat = "0.2.4"


### PR DESCRIPTION
This change adds temperatures display to centerpiece:

![area-2025-01-02-16:51:52](https://github.com/user-attachments/assets/aab68e61-f0d4-4745-80df-70d014f14f5d)

I am initially marking this PR as draft because:

1. I don't want to impose a contribution. If this plugin is not deemed useful/interesting/worth maintaining -- that's totally fine.
2. My Rust skills are at the point where I can write working code but I have never produced code that another person looked at. I completely expect having to rewrite this code and use different idioms/code style.
3. I am not 100% sure about the way I implemented the plugin settings.

    By default, just showing all components' temperatures has two problems:

        1. There are a lot of sensors, not all of them can be interesting
        2. Default labels from sysinfo crate may not be useful at a glance

    I have added a list of dictionaries to the settings that allows a user to opt into displaying components with a user-defined name. Code from the initial commit shows only the hardcoded "gpu" and "cpu" entries.

    The problem is, however, how a user could discover which labels do they need. I am currently using `log::trace`` to print all components, but having to use logs to discover a config seems very awkward. In theory, I could add a subcommand that would display all labels and then exit, but that approach seems to be beyond the scope of a plugin.

    Alternative: add a separate code path to the plugin that would handle empty components list and display all components.

