### PR TITLE
Add font and scale settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,9 +248,14 @@ You can specify alternative configuration locations through:
 1. Use the following config keys to configure centerpiece. These are all config keys including their respective defaults.
 
    ```yml
+   scale: 1.0
    color:
      text: "#ffffff"
      background: "#000000"
+   font:
+     # To list the available fonts on your system, use `fc-list : family | sed 's/,.*$//' | sort | uniq`
+     family: "FiraCode Nerd Font"
+     size: 14
    plugin:
      applications:
        enable: true
@@ -302,9 +307,15 @@ You can specify alternative configuration locations through:
            programs.centerpiece = {
                enable = true;
                config = {
+                   scale = 1.0;
                    color = {
                        text = "#ffffff";
                        background = "#000000";
+                   };
+                   font = {
+                       # To list the available fonts on your system, use `fc-list : family | sed 's/,.*$//' | sort | uniq`
+                       family = "FiraCode Nerd Font";
+                       size = 14;
                    };
                    plugin = {
                        applications = {

--- a/client/src/component/divider.rs
+++ b/client/src/component/divider.rs
@@ -1,14 +1,14 @@
 pub fn view() -> iced::Element<'static, crate::Message> {
     iced::widget::column![iced::widget::horizontal_rule(1)]
         .padding(iced::Padding {
-            top: 1. * crate::REM,
+            top: 1. * crate::rem(),
             right: 0.,
-            bottom: 0.5 * crate::REM,
+            bottom: 0.5 * crate::rem(),
             left: 0.,
         })
         // We're fixing the height here to unify it
         // with the height of entries for a smooth
         // scrolling experience
-        .height(crate::ENTRY_HEIGHT)
+        .height(crate::entry_height())
         .into()
 }

--- a/client/src/component/entry.rs
+++ b/client/src/component/entry.rs
@@ -3,7 +3,7 @@ pub fn view(entry: &crate::model::Entry, active: bool) -> iced::Element<'static,
         iced::widget::container(
             iced::widget::row![
                 iced::widget::text(clipped_title(entry.title.clone()))
-                    .size(1. * crate::REM)
+                    .size(1. * crate::rem())
                     .width(iced::Length::Fill)
                     .shaping(iced::widget::text::Shaping::Advanced),
                 iced::widget::text(if active {
@@ -11,9 +11,9 @@ pub fn view(entry: &crate::model::Entry, active: bool) -> iced::Element<'static,
                 } else {
                     "".to_string()
                 })
-                .size(1. * crate::REM)
+                .size(1. * crate::rem())
             ]
-            .padding(0.5 * crate::REM),
+            .padding(0.5 * crate::rem()),
         )
         .style(move |theme: &iced::Theme| {
             if !active {
@@ -25,7 +25,7 @@ pub fn view(entry: &crate::model::Entry, active: bool) -> iced::Element<'static,
                 border: iced::Border {
                     color: palette.background.base.text,
                     width: 1.,
-                    radius: iced::border::Radius::from(0.1 * crate::REM),
+                    radius: iced::border::Radius::from(0.1 * crate::rem()),
                 },
                 ..Default::default()
             }
@@ -34,8 +34,8 @@ pub fn view(entry: &crate::model::Entry, active: bool) -> iced::Element<'static,
     // We're fixing the height here to unify it
     // with the height of plugin headers for a smooth
     // scrolling experience
-    .height(crate::ENTRY_HEIGHT)
-    .padding([0., 0.75 * crate::REM])
+    .height(crate::entry_height())
+    .padding([0., 0.75 * crate::rem()])
     .into()
 }
 

--- a/client/src/component/plugin_header.rs
+++ b/client/src/component/plugin_header.rs
@@ -5,16 +5,16 @@ pub fn view(plugin: &crate::model::Plugin) -> iced::Element<'static, crate::Mess
             weight: iced::font::Weight::Light,
             ..Default::default()
         })
-        .size(0.75 * crate::REM)]
+        .size(0.75 * crate::rem())]
     // We're fixing the height here to unify it
     // with the height of entries for a smooth
     // scrolling experience
-    .height(crate::ENTRY_HEIGHT)
+    .height(crate::entry_height())
     .padding(iced::Padding {
-        top: 0.8 * crate::REM,
-        right: 1.25 * crate::REM,
-        bottom: 0.5 * crate::REM,
-        left: 1.25 * crate::REM,
+        top: 0.8 * crate::rem(),
+        right: 1.25 * crate::rem(),
+        bottom: 0.5 * crate::rem(),
+        left: 1.25 * crate::rem(),
     })
     .into()
 }

--- a/client/src/component/query_input.rs
+++ b/client/src/component/query_input.rs
@@ -7,12 +7,12 @@ pub fn view(query: &str, add_horizontal_rule: bool) -> iced::Element<'static, cr
         .icon(iced::widget::text_input::Icon {
             font: crate::settings().default_font,
             code_point: '󰍉',
-            size: Some(iced::Pixels(1.3 * crate::REM)),
-            spacing: crate::REM,
+            size: Some(iced::Pixels(1.3 * crate::rem())),
+            spacing: crate::rem(),
             side: iced::widget::text_input::Side::Left,
         })
-        .size(1. * crate::REM)
-        .padding([1.0 * crate::REM, 1.2 * crate::REM])
+        .size(1. * crate::rem())
+        .padding([1.0 * crate::rem(), 1.2 * crate::rem()])
         .style(style),]
     .padding(iced::Padding::default().bottom(1.));
 

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -172,11 +172,11 @@ fn view(centerpice: &Centerpiece) -> iced::Element<Message> {
 
         iced::widget::container::Style {
             background: Some(iced::Background::Color(palette.background.base.color)),
-            border: iced::Border::default().rounded(0.25 * crate::REM),
+            border: iced::Border::default().rounded(0.25 * crate::rem()),
             ..Default::default()
         }
     })
-    .padding(iced::padding::bottom(0.75 * crate::REM))
+    .padding(iced::padding::bottom(0.75 * crate::rem()))
     .into()
 }
 
@@ -317,17 +317,22 @@ fn style(_centerpiece: &Centerpiece, _theme: &iced::Theme) -> iced_layershell::A
 }
 
 fn settings() -> iced_layershell::build_pattern::MainSettings {
+    let settings = settings::Settings::get_or_init();
+
+    let width = (650.0 * settings.scale).round() as u32;
+    let height = (380.0 * settings.scale).round() as u32;
+
     iced_layershell::build_pattern::MainSettings {
         id: Some(APP_ID.into()),
         default_font: iced::Font {
-            family: iced::font::Family::Name("FiraCode Nerd Font"),
+            family: iced::font::Family::Name(&settings.font.family),
             weight: iced::font::Weight::Normal,
             stretch: iced::font::Stretch::Normal,
             style: iced::font::Style::default(),
         },
-        default_text_size: iced::Pixels(crate::REM),
+        default_text_size: iced::Pixels(settings.font.size),
         layer_settings: iced_layershell::settings::LayerShellSettings {
-            size: Some((650, 380)),
+            size: Some((width, height)),
             layer: iced_layershell::reexport::Layer::Top,
             anchor: iced_layershell::reexport::Anchor::Top,
             keyboard_interactivity: iced_layershell::reexport::KeyboardInteractivity::Exclusive,
@@ -518,5 +523,11 @@ impl Centerpiece {
     }
 }
 
-pub const REM: f32 = 14.0;
-pub const ENTRY_HEIGHT: f32 = 2.3 * crate::REM;
+pub fn rem() -> f32 {
+    let settings = settings::Settings::get_or_init();
+    (settings.scale as f32) * settings.font.size
+}
+
+pub fn entry_height() -> f32 {
+    2.3 * rem()
+}

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -14,6 +14,12 @@ in
     enable = lib.mkEnableOption (lib.mdDoc "Centerpiece");
 
     config = {
+      scale = lib.mkOption {
+        default = 1;
+        type = lib.types.float;
+        description = lib.mdDoc "Scale factor";
+      };
+
       color = {
         text = lib.mkOption {
           default = "#ffffff";
@@ -25,6 +31,19 @@ in
           default = "#000000";
           type = lib.types.str;
           description = lib.mdDoc "Background color within centerpiece.";
+        };
+      };
+
+      font = {
+        family = lib.mkOption {
+          default = "FiraCode Nerd Font";
+          type = lib.types.str;
+          description = lib.mdDoc "To list the available fonts on your system, use `fc-list : family | sed 's/,.*$//' | sort | uniq`";
+        };
+        size = lib.mkOption {
+          default = 14;
+          type = lib.types.int;
+          description = lib.mdDoc "Font size";
         };
       };
 

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -181,6 +181,31 @@ impl Default for ColorSettings {
     }
 }
 
+fn default_font_family() -> String {
+    "FiraCode Nerd Font".to_string()
+}
+
+fn default_font_size() -> f32 {
+    14.0
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FontSettings {
+    #[serde(default = "default_font_family")]
+    pub family: String,
+    #[serde(default = "default_font_size")]
+    pub size: f32,
+}
+
+impl Default for FontSettings {
+    fn default() -> Self {
+        Self {
+            family: default_font_family(),
+            size: default_font_size(),
+        }
+    }
+}
+
 fn default_commands() -> Vec<Vec<String>> {
     vec![
         vec![
@@ -333,12 +358,20 @@ pub struct PluginSettings {
     pub wifi: WifiPluginSettings,
 }
 
+fn default_scale() -> f64 {
+    1.
+}
+
 #[derive(Debug, Default, Deserialize)]
 pub struct Settings {
+    #[serde(default = "default_scale")]
+    pub scale: f64,
     #[serde(default)]
     pub plugin: PluginSettings,
     #[serde(default)]
     pub color: ColorSettings,
+    #[serde(default)]
+    pub font: FontSettings,
 }
 
 impl Settings {
@@ -372,7 +405,9 @@ impl Settings {
 
         #[allow(deprecated)]
         if settings.color.surface != *"deprecated" {
-            log::warn!("color.surface has been replaced by automatic shading of the background color in cernterpiece version 1.2.0. Please remove this field from your configuration.")
+            log::warn!(
+                "color.surface has been replaced by automatic shading of the background color in cernterpiece version 1.2.0. Please remove this field from your configuration."
+            )
         }
 
         settings


### PR DESCRIPTION
Continuation of #143. Adds settings to configure the font family and size, as well as a global scaling option. I configure scaling per app since setting it globally performs poorly in many apps I use on linux. Notably. setting `application(...).scale_factor(...)` didn't seem to work on my system, so I resorted to scaling the `REM` and `width/height`.