### PR TITLE
Fuzzy matching with nucleo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
  "iced_runtime",
  "log",
  "networkmanager",
+ "nucleo-matcher",
  "serde",
  "serde_ini",
  "serde_json",
@@ -2650,6 +2651,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -59,3 +59,6 @@ dbus = "0.9.7"
 serde_ini = "0.2.0"
 iced_runtime = "0.13.2"
 systemstat = "0.2.4"
+
+# fuzzy matcher
+nucleo-matcher = "0.3.1"

--- a/client/src/plugin/utils.rs
+++ b/client/src/plugin/utils.rs
@@ -62,6 +62,7 @@ fn fuzzy_match(query: &str, entries: Vec<crate::model::Entry>) -> Vec<crate::mod
                     Utf32Str::new(entry.title.as_ref(), &mut buf),
                     &mut fuzzy_matcher,
                 )
+                .map(|score| score + 1000) // Always prefer title matches
                 // Fallback to substring match against the meta
                 .or_else(|| {
                     substring_atom.score(


### PR DESCRIPTION
Adds fuzzy matching via the [nucleo](https://github.com/helix-editor/nucleo) crate. This should be practically as fast, if not faster, than the previous implementation since nucleo does a prefiltering step with `memchr`. It first fuzzy matches against the `title` of the entry, falling back to substring matching against the `meta`. A match on the `title` receives a `+ 1000` to the score to always beat a match on `meta`.

Before:

![image](https://github.com/user-attachments/assets/79fa0e21-8040-4320-9302-6e663917bb05)

After:

![image](https://github.com/user-attachments/assets/27ebf626-2035-46a4-82d6-81537998753d)
